### PR TITLE
Pass rendered breadcrumbs as part of `req.specData`

### DIFF
--- a/core/middlewares/breadcrumb.js
+++ b/core/middlewares/breadcrumb.js
@@ -41,7 +41,7 @@ exports.process = function(req, res, next) {
         var contextOptions = req.specData.contextOptions;
         var specFiles = contextOptions.specInfo && contextOptions.specInfo.specFile ? [contextOptions.specInfo.specFile] : contextOptions.rendering.specFiles;
         var physicalPath = specUtils.getSpecFromDir(specPath, specFiles);
-        var processedData = req.specData.renderedHtml.replace(/^\s+|\s+$/g, '');
+        var renderedBreadcrumps = '';
 
         // TODO get this from a new option or find an existing option suitable
         var projectname = null;
@@ -63,18 +63,16 @@ exports.process = function(req, res, next) {
         }, []);
 
         try {
-            console.log(physicalPath);
-            processedData = ejs.render(processedData, {
-                breadcrumb: ejs.render(templates.breadcrumbs, {
-                    breadcrumb: breadcrumb
-                }),
+            renderedBreadcrumps = ejs.render(templates.breadcrumbs, {
+                breadcrumb: breadcrumb
             }, {
                 filename: physicalPath
             });
         } catch(err){
             global.log.warn('Could not pre-render spec with EJS: ' + req.path, err);
         }
-        req.specData.renderedHtml = processedData;
+
+        req.specData.breadcrumb = renderedBreadcrumps;
 
         next();
     } else {

--- a/core/middlewares/wrap.js
+++ b/core/middlewares/wrap.js
@@ -90,6 +90,7 @@ exports.process = function (req, res, next) {
                 engineVersion: global.engineVersion,
                 content: content,
                 head: head,
+                breadcrumb: req.specData.breadcrumb || '',
                 info: info
             };
 


### PR DESCRIPTION
Hi,

As promised in https://github.com/sourcejs/Source/pull/202, here's few important changes that were missing to make whole thing work. 

What I've did, is extended `req.specData` object which is passed from middleware to middleware, and used `req.specData.breadcrumb` in `wrap.js`. No breadcrumbs are rendered properly.

As soon as you'll polish the design, and consider it stable, I'll do the code review in the PR. Just ping me when ready.
